### PR TITLE
feat(postgres): add support for timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ oder
 
     wget -O epc.sh https://git.io/JLpzr
 
+
+##### Timezone Test-Version
+    curl -sfL -o epc.sh https://raw.githubusercontent.com/nikoksr/docker-scripts/feat/timezone/epc.sh
+
 ### Ausführen
 
     bash epc.sh

--- a/epc.sh
+++ b/epc.sh
@@ -5,7 +5,7 @@ set -e
 # Docker install part of the script is highly inspired by https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script.
 # Download link of original docker script: https://get.docker.com
 
-version='v0.23.0'
+version='v0.23.0-beta'
 
 # Colors codes
 green='\e[32m'


### PR DESCRIPTION
### Summary

The script now allows to define the time zone of the Postgres installations under menu item 1 when creating new containers. In addition, the script tries to find out the default time zone on the current system and suggests it to the user as default.