### PR TITLE
feat(install): redo docker installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,13 @@ Zum Downloaden des Skripts wird entweder das Programm `curl` oder `wget` benöti
 
 ### Download
 
-> Sollten die gekürzten URLs nicht funktionieren, können Sie auch die originale URL verwenden: <https://raw.githubusercontent.com/nikoksr/docker-scripts/main/epc.sh>
+> Sollten die gekürzten URLs nicht funktionieren, können Sie auch die vollständige URL verwenden: <https://raw.githubusercontent.com/nikoksr/docker-scripts/main/epc.sh>
 
     curl -sfL -o epc.sh https://git.io/JLpzr
 
 oder
 
     wget -O epc.sh https://git.io/JLpzr
-
-
-##### Timezone Test-Version
-    curl -sfL -o epc.sh https://raw.githubusercontent.com/nikoksr/docker-scripts/feat/timezone/epc.sh
 
 ### Ausführen
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Interaktives Shell-Menü zum vereinfachten Erzeugen, Listen, Entfernen und Beoba
 
 Sollte der Skript dafür verwendet werden, um Docker zu installieren, werden `root`-Rechte
 benötigt. Sie sollten dazu das Programm `sudo` installiert und ihrem aktuellen Benutzer
-die Rechte gegeben haben, dieses Programm verwenden zu drüfen.
+die Rechte gegeben haben, dieses Programm verwenden zu dürfen.
 
 Sollte das Installieren des `sudo` Programmes aus irgendwelchen Gründen nicht möglich sein,
 können Sie auch auf den Benutzer `root` zurückgreifen. Es wird jedoch deutlich dazu geraten,

--- a/epc.sh
+++ b/epc.sh
@@ -151,8 +151,8 @@ Beende Skript aufgrund von unzureichenden Berechtigungen.
 #
 ####
 
-# This is the url to the official Docker install script (hosted on GitHub) which will be used here to.. install docker.
-INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/docker/docker-install/master/install.sh"
+# This is the url to the official Docker install script which will be used here to.. install docker.
+INSTALL_SCRIPT_URL="https://get.docker.com/"
 
 install_docker() {
 

--- a/epc.sh
+++ b/epc.sh
@@ -1,32 +1,23 @@
 #!/usr/bin/env bash
-
 set -e
 
-# Docker install part of the script is highly inspired by https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script.
-# Download link of original docker script: https://get.docker.com
+####
+#
+# VARS
+#
+####
 
-version='v0.23.0-beta'
+version='v0.24.0-beta'
+
+# Visual separation bar
+separator='######################################################################'
 
 # Colors codes
 green='\e[32m'
 blue='\e[96m'
 red='\e[31m'
 dim='\e[2m'
-undim='\e[22m'
 no_color='\e[0m'
-
-separator='######################################################################'
-
-# The channel to install from:
-#   * nightly
-#   * test
-#   * stable
-#   * edge (deprecated)
-CHANNEL="stable"
-DOWNLOAD_URL="https://download.docker.com"
-REPO_FILE="docker-ce.repo"
-
-sh_c='bash -c'
 
 # Color functions. Accept string and echo it in the respective color.
 green() {
@@ -45,335 +36,14 @@ dim() {
 	echo "$dim$1$no_color"
 }
 
-
 ####
 #
-# DOCKER INSTALLATION
+# HELPER FUNCTIONS
 #
 ####
-
-
-is_wsl() {
-	case "$(uname -r)" in
-	*microsoft* ) true ;; # WSL 2
-	*Microsoft* ) true ;; # WSL 1
-	* ) false;;
-	esac
-}
-
-is_darwin() {
-	case "$(uname -s)" in
-	*darwin* ) true ;;
-	*Darwin* ) true ;;
-	* ) false;;
-	esac
-}
 
 command_exists() {
-	command -v "$@" > /dev/null 2>&1
-}
-
-get_distribution() {
-	lsb_dist=""
-	# Every system that we officially support has /etc/os-release
-	if [ -r /etc/os-release ]; then
-		lsb_dist="$(. /etc/os-release && echo "$ID")"
-	fi
-	# Returning an empty string here should be alright since the
-	# case statements don't act unless you provide an actual value
-	echo "$lsb_dist"
-}
-
-# add_debian_backport_repo adds the necessary debian backport to source list if not already in it.
-# Some package installs may fail otherwise.
-add_debian_backport_repo() {
-	debian_version="$1"
-	backports="deb http://ftp.debian.org/debian $debian_version-backports main"
-	if ! grep -Fxq "$backports" /etc/apt/sources.list; then
-		(set -x; $sh_c "echo \"$backports\" >> /etc/apt/sources.list")
-	fi
-}
-
-# check_forked checks if this is a forked Linux distro for example Kali is forked from Debian.
-check_forked() {
-
-	# Check for lsb_release command existence, it usually exists in forked distros
-	if ! command_exists lsb_release; then
-		return
-	fi
-
-	# Check if the `-u` option is supported
-	set +e
-	lsb_release -a -u > /dev/null 2>&1
-	lsb_release_exit_code=$?
-	set -e
-
-	# Check if the command has exited successfully, it means we're in a forked distro
-	if [ "$lsb_release_exit_code" = "0" ]; then
-		# Get the upstream release info
-		lsb_dist=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'id' | cut -d ':' -f 2 | tr -d '[:space:]')
-		dist_version=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'codename' | cut -d ':' -f 2 | tr -d '[:space:]')
-
-		return
-	fi
-
-	if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ] && [ "$lsb_dist" != "raspbian" ]; then
-		if [ "$lsb_dist" = "osmc" ]; then
-			# OSMC runs Raspbian
-			lsb_dist=raspbian
-		else
-			# We're Debian and don't even know it!
-			lsb_dist=debian
-		fi
-		dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
-		case "$dist_version" in
-			10)
-				dist_version="buster"
-			;;
-			9)
-				dist_version="stretch"
-			;;
-			8|'Kali Linux 2')
-				dist_version="jessie"
-			;;
-		esac
-	fi
-}
-
-is_docker_daemon_running() {
-	if pgrep -f docker > /dev/null; then
-		return 0
-	fi
-	return 1
-}
-
-start_docker_daemon() {
-	if command_exists systemctl; then
-		systemctl is-active --quiet docker.service || systemctl enable --now --quiet docker.service > /dev/null
-	# elif command_exists service; then
-	# 	service docker status > /dev/null || service docker start > /dev/null
-	else
-		pgrep -f docker > /dev/null || dockerd & > /dev/null
-	fi
-}
-
-install_docker() {
-		echo -ne "
-
-$(dim $separator)
-$(dim '# ')$(blue 'Docker Installation')
-$(dim $separator)
-
-"
-
-	# perform some very rudimentary platform detection
-	echo "> Bereite Docker Installation vor..."
-	echo "> Versuche Platform zu erkennen..."
-	lsb_dist=$( get_distribution )
-	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
-
-	if is_wsl; then
-		echo
-		echo ">   WSL ERKANNT: Es wird empfohlen Docker-Desktop für Windows zu verwenden"
-		echo "     -> https://www.docker.com/products/docker-desktop"
-		echo
-		exit 1
-	fi
-
-	case "$lsb_dist" in
-
-		ubuntu)
-			if command_exists lsb_release; then
-				dist_version="$(lsb_release --codename | cut -f2)"
-			fi
-			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
-				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
-			fi
-		;;
-
-		debian|raspbian)
-			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
-			case "$dist_version" in
-				10)
-					dist_version="buster"
-				;;
-				9)
-					dist_version="stretch"
-				;;
-				8)
-					dist_version="jessie"
-				;;
-			esac
-		;;
-
-		centos|rhel)
-			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
-				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-			fi
-		;;
-
-		*)
-			if command_exists lsb_release; then
-				dist_version="$(lsb_release --release | cut -f2)"
-			fi
-			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
-				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-			fi
-		;;
-
-	esac
-
-	# Check if this is a forked Linux distro
-	check_forked
-
-	# Run setup for each distro accordingly
-	case "$lsb_dist" in
-		ubuntu|debian|raspbian)
-			echo ">   $lsb_dist erkannt..."
-			pre_reqs="apt-transport-https ca-certificates curl"
-			if [ "$lsb_dist" = "debian" ]; then
-				# libseccomp2 does not exist for debian jessie main repos for aarch64
-				if [ "$(uname -m)" = "aarch64" ] && [ "$dist_version" = "jessie" ]; then
-					echo ">     Füge potenziell fehlende Debian-Backports hinzu..."
-					add_debian_backport_repo "$dist_version"
-				fi
-			fi
-
-			echo ">     Update apt package index und installiere nötige Pakete um HTTPS Repository benutzen zu können..."
-			if ! command -v gpg > /dev/null; then
-				pre_reqs="$pre_reqs gnupg"
-			fi
-			apt_repo="deb [arch=$(dpkg --print-architecture)] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
-			(
-				export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=0
-				$sh_c 'apt-get update -qq >/dev/null'
-				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
-				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
-				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
-				$sh_c 'apt-get update -qq >/dev/null'
-			)
-			pkg_version=""
-			if [ -n "$VERSION" ]; then
-				# Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
-				pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g").*-0~$lsb_dist"
-				search_command="apt-cache madison 'docker-ce' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
-				pkg_version="$($sh_c "$search_command")"
-				echo ">     Suche in Repository nach Version '$VERSION'"
-				if [ -z "$pkg_version" ]; then
-					echo
-					echo ">     FEHLER: '$VERSION' konnte nicht in den apt-cache madison Ergebnissen gefunden werden."
-					echo
-					exit 1
-				fi
-				search_command="apt-cache madison 'docker-ce-cli' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
-				# Don't insert an = for cli_pkg_version, we'll just include it later
-				cli_pkg_version="$($sh_c "$search_command")"
-				pkg_version="=$pkg_version"
-			fi
-
-			echo ">     Installiere Docker..."
-			(
-				if [ -n "$cli_pkg_version" ]; then
-					$sh_c "apt-get install -y -qq --no-install-recommends docker-ce-cli=$cli_pkg_version >/dev/null"
-				fi
-				$sh_c "apt-get install -y -qq --no-install-recommends docker-ce$pkg_version >/dev/null"
-			)
-			;;
-		centos|fedora|rhel)
-			echo ">   $lsb_dist erkannt..."
-			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
-			if ! curl -Ifs "$yum_repo" > /dev/null; then
-				echo ">     Fehler: Konnte nicht mit 'curl' die Repository-Datei $yum_repo holen. Existiert die Datei?"
-				exit 1
-			fi
-			if [ "$lsb_dist" = "fedora" ]; then
-				pkg_manager="dnf"
-				config_manager="dnf config-manager"
-				enable_channel_flag="--set-enabled"
-				disable_channel_flag="--set-disabled"
-				pre_reqs="dnf-plugins-core"
-				pkg_suffix="fc$dist_version"
-			else
-				pkg_manager="yum"
-				config_manager="yum-config-manager"
-				enable_channel_flag="--enable"
-				disable_channel_flag="--disable"
-				pre_reqs="yum-utils"
-				pkg_suffix="el"
-			fi
-
-			echo ">     Füge Docker-Stable Dnf-Repository hinzu..."
-			(
-				$sh_c "$pkg_manager install -y -q $pre_reqs"
-				$sh_c "$config_manager --add-repo $yum_repo"
-
-				if [ "$CHANNEL" != "stable" ]; then
-					$sh_c "$config_manager $disable_channel_flag docker-ce-*"
-					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
-				fi
-				$sh_c "$pkg_manager makecache"
-			)
-			pkg_version=""
-			if [ -n "$VERSION" ]; then
-				pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g").*$pkg_suffix"
-				search_command="$pkg_manager list --showduplicates 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
-				pkg_version="$($sh_c "$search_command")"
-				echo ">     Suche in Repository nach Version '$VERSION'"
-				if [ -z "$pkg_version" ]; then
-					echo
-					echo ">     FEHLER: '$VERSION' nicht in $pkg_manager Ergebnisliste gefunden."
-					echo
-					exit 1
-				fi
-				search_command="$pkg_manager list --showduplicates 'docker-ce-cli' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
-				# It's okay for cli_pkg_version to be blank, since older versions don't support a cli package
-				cli_pkg_version="$($sh_c "$search_command" | cut -d':' -f 2)"
-				# Cut out the epoch and prefix with a '-'
-				pkg_version="-$(echo "$pkg_version" | cut -d':' -f 2)"
-			fi
-
-			echo ">     Installiere Docker..."
-			(
-				# install the correct cli version first
-				if [ -n "$cli_pkg_version" ]; then
-					$sh_c "$pkg_manager install -y -q docker-ce-cli-$cli_pkg_version"
-				fi
-				$sh_c "$pkg_manager install -y -q docker-ce$pkg_version"
-			)
-			echo_docker_as_nonroot
-			;;
-		arch|manjaro)
-			echo ">   $lsb_dist erkannt..."
-			echo ">     Installiere Docker..."
-			(
-				pacman -S --needed --noconfirm --quiet docker > /dev/null
-			)
-			;;
-		*)
-			if [ -z "$lsb_dist" ]; then
-				if is_darwin; then
-					echo
-					echo ">   FEHLER: Nicht unterstütztes Betriebssystem 'macOS'."
-					echo "    Bitte installieren Sie Docker-Desktop für macOS -> https://www.docker.com/products/docker-desktop"
-					echo
-					exit 1
-				fi
-			fi
-			echo
-			echo ">   FEHLER: Nicht unterstützte Distribution '$lsb_dist'"
-			echo
-			exit 1
-			;;
-	esac
-
-	# Verify installation
-	if ! command_exists docker; then
-		echo "> Docker konnte nicht installiert werden..."
-		exit 1
-	fi
-
-	echo "> Docker wurde erfolgreich installiert..."
-	exit 0
+	command -v "$@" >/dev/null 2>&1
 }
 
 get_timezone() {
@@ -381,19 +51,19 @@ get_timezone() {
 
 	# Check if /etc/localtime is a symlink as expected
 	if filename=$(readlink /etc/localtime); then
-    	timezone=${filename#*zoneinfo/}
-    	if [[ $timezone = "$filename" || ! $timezone =~ ^[^/]+/[^/]+$ ]]; then
-	        # not pointing to expected location or not Region/City
-    	    >&2 echo "$filename points to an unexpected location"
-        	return 1
-    	fi
+		timezone=${filename#*zoneinfo/}
+		if [[ $timezone = "$filename" || ! $timezone =~ ^[^/]+/[^/]+$ ]]; then
+			# not pointing to expected location or not Region/City
+			echo >&2 "$filename points to an unexpected location"
+			return 1
+		fi
 
 		echo "$timezone"
 		return 0
 	fi
 
 	# Fallback; use ipapi to get timezone
-	timezone=$(curl -s 'https://ipapi.co/timezone' > /dev/null)
+	timezone=$(curl -s 'https://ipapi.co/timezone' >/dev/null)
 
 	# Fallback to fixed default timezone.
 	if [ -z "$timezone" ]; then
@@ -404,12 +74,146 @@ get_timezone() {
 	return 0
 }
 
+is_user_root() {
+	if [ "$EUID" -eq 0 ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+is_user_in_docker_group() {
+	if id -nG "$USER" | grep -qw "docker"; then
+		return 0
+	fi
+
+	return 1
+}
+
+are_permissions_sufficient() {
+	# If docker is not installed user has to be root
+	if ! command_exists docker; then
+		if is_user_root; then
+			return 0
+		fi
+		echo -ne "
+$(dim $separator)
+$(dim '# ')$(blue 'Docker Installation')
+$(dim $separator)
+
+Docker ist enweder nicht installiert oder die Installation konnte nicht gefunden werden. Bitte starten
+Sie den Skript (vorzugsweise) mit 'sudo' oder als 'root' Benutzer neu, um die automatische Installation
+und Einrichtung von Docker zu starten.
+"
+		return 1
+	fi
+
+	# If docker service is not running, need root to start and enable service
+	if ! is_docker_daemon_running; then
+		if is_user_root; then
+			return 0
+		fi
+		echo -ne "
+$(dim $separator)
+$(dim '# ')$(blue 'Docker Installation')
+$(dim $separator)
+
+Docker-Daemon scheint nicht aktiviert zu sein. Bitte starten Sie den Skript (vorzugsweise) mit 'sudo' oder
+als 'root' Benutzer neu, um die automatische Aktivierung des Docker-Daemons zu starten.
+"
+		return 1
+	fi
+
+	# If docker is installed user has to be in docker group
+	if ! is_user_in_docker_group && ! is_user_root; then
+		echo -ne "
+$(dim $separator)
+$(dim '# ')$(blue 'Berechtigung')
+$(dim $separator)
+
+Der aktuelle Benutzer muss entweder Mitglied der 'docker' Gruppe sein oder dieser Skript muss (vorzugsweise)
+mit 'sudo' oder als 'root' Benutzer ausgeführt werden.
+Um den aktuellen Benutzer zur Gruppe 'docker' hinzuzufügen, führen Sie folgenden Befehl aus und melden sich anschließend ab und wieder an:
+
+  usermod -a -G docker $USER
+
+Beende Skript aufgrund von unzureichenden Berechtigungen.
+"
+		return 1
+	else
+		return 0
+	fi
+}
+
+####
+#
+# DOCKER INSTALLATION
+#
+####
+
+# This is the url to the official Docker install script (hosted on GitHub) which will be used here to.. install docker.
+INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/docker/docker-install/master/install.sh"
+
+install_docker() {
+
+	echo -ne "
+$(dim $separator)
+$(dim '# ')$(blue 'Docker Installation')
+$(dim $separator)
+
+$(dim "> Dieser Vorgang kann einige Minuten dauern.")
+
+"
+
+	download_command=""
+	if command_exists wget; then
+		download_command="wget -qO-"
+	elif command_exists curl; then
+		download_command="curl -s"
+	else
+		echo -e "$red""Fehler: Es wurde kein passender Downloader gefunden. Erlaubte Downloader: curl, wget""$no_color"
+		exit 1
+	fi
+
+	systemctl is-active --quiet docker.socket && systemctl stop --quiet docker.socket
+
+	if ! sh <($download_command $INSTALL_SCRIPT_URL) >/dev/null; then
+
+		echo -ne "
+$(red 'Warnung:') Exit-Code des Installers deutet auf Fehler im Installationsprozess hin.
+         -> Installation wahrscheinlich unvollständig.
+
+"
+		# Possible repair commands
+		# dpkg --configure -a
+		# apt install -f
+
+		exit 1
+	fi
+}
+
+is_docker_daemon_running() {
+	if pgrep -f docker >/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+start_docker_daemon() {
+	if command_exists systemctl; then
+		systemctl is-active --quiet docker.service || systemctl enable --now --quiet docker.service >/dev/null
+	# elif command_exists service; then
+	# 	service docker status > /dev/null || service docker start > /dev/null
+	else
+		pgrep -f docker >/dev/null || dockerd &
+	fi
+}
+
 ####
 #
 # CONTAINER MANIPULATION
 #
 ####
-
 
 create_postgres_containers() {
 	echo -ne "
@@ -427,9 +231,9 @@ $(blue "### Konfiguration")
 
 	# Anzahl, Port and Postgres Version
 	echo -ne "> Anzahl Container $(dim '(1)'):                          "
-	read container_count
+	read -r container_count
 	if [ -z "$container_count" ]; then
-    	container_count=1
+		container_count=1
 	fi
 
 	# Get currently highest port in use
@@ -445,47 +249,47 @@ $(blue "### Konfiguration")
 
 	for idx in "${!ports_list[@]}"; do
 		# Last port reached; set port equal to last port + 1
-		if [ -z ${ports_list[$(( idx + 1))]} ]; then
-			highest_port=$(( ${ports_list[idx]} + 1 ))
+		if [ -z "${ports_list[$((idx + 1))]}" ]; then
+			highest_port=$(("${ports_list[idx]}" + 1))
 			break
 		fi
 
 		# Check if all containers fit in port range
-		if [[ ( $(( ${ports_list[idx]} + $container_count + 1 )) < ${ports_list[$(( idx + 1))]} ) ]]; then
-			highest_port=$(( ${ports_list[idx]} + 1 ))
+		if [[ ($(("${ports_list[idx]}" + "$container_count" + 1)) < ${ports_list[$((idx + 1))]}) ]]; then
+			highest_port=$(("${ports_list[idx]}" + 1))
 			break
 		fi
 	done
 
-	# If no port assigned default to postgres default port
+	# If no taken ports were detected use postgres default port as container port
 	if [[ "$highest_port" -eq 0 ]]; then
 		highest_port=5432
 	fi
 
 	echo -ne "> Port $(dim '('$highest_port')'):                                   "
-	read external_port
+	read -r external_port
 	if [ -z "$external_port" ]; then
-    	external_port=$highest_port
+		external_port=$highest_port
 	fi
 
 	echo
 	echo -ne "> Postgres Version $(dim '(latest)'):                     "
-	read postgres_version
+	read -r postgres_version
 	if [ -z "$postgres_version" ]; then
-    	postgres_version="latest"
+		postgres_version="latest"
 	fi
 
 	# Logging behaviour
 	echo
 	echo -ne "> Maximal Anzahl Log Dateien $(dim '(5)'):                "
-	read max_log_file
+	read -r max_log_file
 	if [ -z "$max_log_file" ]; then
 		max_log_file="5"
 	fi
 
 	default_log_file_size="20m"
 	echo -ne "> Maximale Größer einer Log-Datei $(dim '('$default_log_file_size')'):         "
-	read max_log_file_size
+	read -r max_log_file_size
 	if [ -z "$max_log_file_size" ]; then
 		max_log_file_size="$default_log_file_size"
 	fi
@@ -503,10 +307,10 @@ $(blue "### Konfiguration")
 	fi
 
 	# Timezone
-	local default_timezone=$(get_timezone)
+	default_timezone="$(get_timezone)"
 	echo
-	echo -ne "> Zeitzone $(dim '('$default_timezone')'):                      "
-	read timezone
+	echo -ne "> Zeitzone $(dim '('"$default_timezone"')'):                      "
+	read -r timezone
 	if [ -z "$timezone" ]; then
 		timezone="$default_timezone"
 	fi
@@ -521,24 +325,24 @@ $(blue "### Konfiguration")
    $(blue '4)') Nie
 
    $(blue '>') "
-	read choice
-    case "$choice" in
-		2) restart="on-failure";;
-		3) restart="unless-stopped";;
-		4) restart="no";;
-		*) ;;
-    esac
+	read -r choice
+	case "$choice" in
+	2) restart="on-failure" ;;
+	3) restart="unless-stopped" ;;
+	4) restart="no" ;;
+	*) ;;
+	esac
 	echo
 
 	# Postgres user password
 	echo -ne "> Postgres Admin Passwort $(dim '(postgres)'):            "
-	read -s admin_pwd
+	read -r -s admin_pwd
 	echo
 	if [ -z "$admin_pwd" ]; then
 		admin_pwd="postgres"
 	else
 		echo -ne "> Passwort bestätigen:                           "
-		read -s admin_pwd_confirm
+		read -r -s admin_pwd_confirm
 		echo
 		if [ ! "$admin_pwd" = "$admin_pwd_confirm" ]; then
 			echo
@@ -550,7 +354,7 @@ $(blue "### Konfiguration")
 
 	# Database name
 	echo -ne "> Datenbank Name $(dim '(postgres)'):                     "
-	read db_name
+	read -r db_name
 	if [ -z "$db_name" ]; then
 		db_name="postgres"
 	fi
@@ -563,10 +367,12 @@ $(blue "### Konfiguration")
 	# Create multiple containers
 	echo -ne "\n$(blue "### Container starten")\n\n"
 
+	# Follow an example request to find out systems IP address. 'ip a ' is too verbose and
+	# shows ip addresses of ALL network interfaces on the system.
 	ip=$(ip route get 1.1.1.1 | sed -n '/src/{s/.*src *\([^ ]*\).*/\1/p;q}')
 	end_port=$((external_port + container_count - 1))
 
-	for port in `seq $external_port $end_port`; do
+	for port in $(seq $external_port $end_port); do
 		local name="postgres_$RANDOM"
 		docker run \
 			--name "$name" \
@@ -577,10 +383,10 @@ $(blue "### Konfiguration")
 			-e POSTGRES_PASSWORD="$admin_pwd" \
 			-e TZ="$timezone" \
 			-d \
-			postgres:"$postgres_version" > /dev/null
+			postgres:"$postgres_version" >/dev/null
 
 		# Only create database if name was given. Skip on empty.
-		if [ ! -z "$db_name" ] && [ ! "$db_name" = "postgres" ] ; then
+		if [ ! -z "$db_name" ] && [ ! "$db_name" = "postgres" ]; then
 
 			# Wait 90 seconds for container to start
 			is_running=1
@@ -590,21 +396,21 @@ $(blue "### Konfiguration")
 					break
 				fi
 				sleep 1s
-				i=$[$i+1]
+				i=$(("$i" + 1))
 			done
 
 			# Check if container is running and create database if so.
 			if [ "$is_running" -eq 0 ]; then
-				docker exec -it "$name" psql -U postgres -c "CREATE DATABASE $db_name;" && \
-				echo "> Datenbank $db_name erfolgreich erstellt..."
+				docker exec -it "$name" psql -U postgres -c "CREATE DATABASE $db_name;" &&
+					echo "> Datenbank $db_name erfolgreich erstellt..."
 			else
 				echo "> $(red 'Warnung:') Konnte Datenbank nicht anlegen, da Container nicht im erwarteten Zeitraum gestartet ist..."
 			fi
 		fi
 
-		echo -e "> Container $(dim $name) gestartet auf $(green $ip:$port)"
-    	done
-		echo
+		echo -e "> Container $(dim $name) gestartet auf $(green "$ip":"$port")"
+	done
+	echo
 }
 
 remove_all_postgres_containers() {
@@ -629,16 +435,16 @@ $(dim $separator)
 
 "
 
-	read -p "> Möchten Sie fortfahren (j/N)? " choice
+	read -r -p "> Möchten Sie fortfahren (j/N)? " choice
 
 	if [ -z "$choice" ]; then
-    	choice="n"
+		choice="n"
 	fi
 
 	case $choice in
-		"j"|"J"|"y"|"Y") ;;
-		*) exit 0 ;;
-    esac
+	"j" | "J" | "y" | "Y") ;;
+	*) exit 0 ;;
+	esac
 
 	echo -ne "
 
@@ -649,16 +455,16 @@ $(dim $separator)
 
 "
 
-	read -p "> Möchten Sie trotzdem fortfahren (j/N)? " choice
+	read -r -p "> Möchten Sie trotzdem fortfahren (j/N)? " choice
 
 	if [ -z "$choice" ]; then
-    	choice="n"
+		choice="n"
 	fi
 
 	case $choice in
-		"j"|"J"|"y"|"Y") ;;
-		*) exit 0 ;;
-    esac
+	"j" | "J" | "y" | "Y") ;;
+	*) exit 0 ;;
+	esac
 
 	echo "> Entferne Container"
 	echo
@@ -682,30 +488,30 @@ $(dim $separator)
    Sollte Sie sich zuvor eine Liste dieser Images ansehen wollen, beenden Sie den Skript mit CTRL+C
    und führen Sie folgenden Befehl aus:
 
-   $(blue 'docker images | grep 'postgres'')
+   $(blue 'docker images | grep '"'single quotes'"'')
 
 
 "
 
-	read -p "> Möchten Sie fortfahren (j/N)? " choice
+	read -r -p "> Möchten Sie fortfahren (j/N)? " choice
 
 	if [ -z "$choice" ]; then
-    	choice="n"
+		choice="n"
 	fi
 
 	case $choice in
-		"j"|"J"|"y"|"Y") ;;
-		*) exit 0 ;;
-    esac
+	"j" | "J" | "y" | "Y") ;;
+	*) exit 0 ;;
+	esac
 
 	echo "> Entferne Images"
 	echo
 
-	docker rmi $(docker images | grep 'postgres')
+	docker rmi "$(docker images | grep 'postgres')"
 }
 
 list_postgres_containers() {
-		echo -ne "
+	echo -ne "
 
 $(dim $separator)
 $(dim '# ')$(blue 'Postgres-Container auflisten')
@@ -721,7 +527,7 @@ postgres_containers_stats() {
 }
 
 postgres_containers_logs() {
-		echo -ne "
+	echo -ne "
 
 $(dim $separator)
 $(dim '# ')$(blue 'Postgres-Container Logs')
@@ -732,30 +538,30 @@ $(dim $separator)
 	docker container ls | grep 'postgres:*'
 
 	echo
-	echo -ne $(blue 'Container-ID eingeben')
+	echo -ne "$(blue 'Container-ID eingeben')"
 	echo
-	read -p "> " id
+	read -r -p "> " id
 
 	if [ -z "$id" ]; then
 		exit 1
 	fi
 
 	echo
-	read -p "> Live verfolgen (j/N)? " choice
+	read -r -p "> Live verfolgen (j/N)? " choice
 
 	if [ -z "$choice" ]; then
-    	choice="n"
+		choice="n"
 	fi
 
 	clear
 	case $choice in
-		"j"|"J"|"y"|"Y") docker container logs --since 0s -f "$id";;
-		*) docker container logs "$id";;
-    esac
+	"j" | "J" | "y" | "Y") docker container logs --since 0s -f "$id" ;;
+	*) docker container logs "$id" ;;
+	esac
 }
 
 postgres_containers_top() {
-		echo -ne "
+	echo -ne "
 
 $(dim $separator)
 $(dim '# ')$(blue 'Postgres-Container Top')
@@ -768,7 +574,7 @@ $(dim $separator)
 	echo
 	echo -ne "$(blue 'Container-ID eingeben')"
 	echo
-	read -p "> " id
+	read -r -p "> " id
 
 	if [ -z "$id" ]; then
 		exit 1
@@ -799,10 +605,10 @@ $(dim $separator)"
 }
 
 # menu prints the general and interactive navigation menu.
-menu(){
-print_header
+menu() {
+	print_header
 
-echo -ne "
+	echo -ne "
 
 $(green '1)') Postgres-Container erstellen & starten
 $(green '2)') Postgres-Container auflisten
@@ -814,88 +620,49 @@ $(green '7)') Ungenutzte Postgres-Images entfernen
 $(red '0)') Exit
 
 $(blue '>') "
-    read a
-    case $a in
-		1) clear;print_header;create_postgres_containers;;
-		2) clear;print_header;list_postgres_containers;;
-		3) clear;print_header;postgres_containers_stats;;
-		4) clear;print_header;postgres_containers_logs;;
-		5) clear;print_header;postgres_containers_top;;
-		6) clear;print_header;remove_all_postgres_containers;;
-		7) clear;print_header;remove_unused_postgres_images;;
-		0) exit 0;;
-		*) echo -e $red"Warnung: Option existiert nicht."$no_color; menu;;
-    esac
-}
-
-is_user_root() {
-	if [ "$EUID" -eq 0 ]; then
-		return 0
-	else
-		return 1
-	fi
-}
-
-is_user_in_docker_group() {
-		if id -nG "$USER" | grep -qw "docker"; then
-    		return 0
-		fi
-
-		return 1
-}
-
-are_permissions_sufficient() {
-	# If docker is not installed user has to be root
-	if ! command_exists docker ; then
-		if is_user_root; then
-			return 0
-		fi
-		echo -ne "
-$(dim $separator)
-$(dim '# ')$(blue 'Docker Installation')
-$(dim $separator)
-
-Docker ist enweder nicht installiert oder die Installation konnte nicht gefunden werden. Bitte starten
-Sie den Skript als 'root' Benutzer neu, um die automatische Installation und Einrichtung von Docker zu starten.
-"
-		return 1
-	fi
-
-	# If docker service is not running, need root to start and enable service
-	if ! is_docker_daemon_running; then
-		if is_user_root; then
-			return 0
-		fi
-		echo -ne "
-$(dim $separator)
-$(dim '# ')$(blue 'Docker Installation')
-$(dim $separator)
-
-Docker-Daemon scheint nicht aktiviert zu sein. Bitte starten Sie den Skript als 'root' Benutzer neu, um die
-automatische Aktivierung des Docker-Daemons zu starten.
-"
-	return 1
-	fi
-
-	# If docker is installed user has to be in docker group
-	if ! is_user_in_docker_group && ! is_user_root; then
-			echo -ne "
-$(dim $separator)
-$(dim '# ')$(blue 'Berechtigung')
-$(dim $separator)
-
-Der aktuelle Benutzer muss entweder Mitglied der 'docker'-Gruppe sein oder dieser Skript
-muss als 'root' Benutzer ausgeführt werden.
-Um den aktuellen Benutzer zur Gruppe 'docker' hinzuzufügen, führen Sie folgenden Befehl aus:
-
-  usermod -a -G docker $USER && newgrp docker
-
-Beende Skript aufgrund von unzureichenden Berechtigungen.
-"
-		return 1
-	else
-		return 0
-	fi
+	read -r a
+	case $a in
+	1)
+		clear
+		print_header
+		create_postgres_containers
+		;;
+	2)
+		clear
+		print_header
+		list_postgres_containers
+		;;
+	3)
+		clear
+		print_header
+		postgres_containers_stats
+		;;
+	4)
+		clear
+		print_header
+		postgres_containers_logs
+		;;
+	5)
+		clear
+		print_header
+		postgres_containers_top
+		;;
+	6)
+		clear
+		print_header
+		remove_all_postgres_containers
+		;;
+	7)
+		clear
+		print_header
+		remove_unused_postgres_images
+		;;
+	0) exit 0 ;;
+	*)
+		echo -e "$red""Warnung: Option existiert nicht.""$no_color"
+		menu
+		;;
+	esac
 }
 
 # entrypoint for the application.
@@ -908,7 +675,7 @@ entrypoint() {
 		exit 1
 	fi
 
-	# Install docker if not already
+	# Install docker if not already exists
 	if ! command_exists docker; then
 		install_docker
 	fi
@@ -918,7 +685,7 @@ entrypoint() {
 		start_docker_daemon
 	fi
 
-	# Start options menu only when dependencies are statisfied
+	# Start options menu only(!) when dependencies are statisfied
 	clear
 	menu
 }


### PR DESCRIPTION
### Summary 

Instead of the manually implemented install script, we now rely internally on the
official Docker install script. The source code for this script is available [here](https://get.docker.com/).
The decision was made because the installer needs regular maintenance (new OS versions
etc) and I just don't have the time for that.

The only minor disadvantage is that the one-time installation of Docker is not quite
as clear and beautiful but the advantage is that, we use the official script, which is
maintained and kept up-to-date by Docker themselves.