### PR TITLE
fix(funcs): update funcs to remove dangling images and stopped containers

### DIFF
--- a/epc.sh
+++ b/epc.sh
@@ -7,7 +7,7 @@ set -e
 #
 ####
 
-version='v0.24.2-alpha'
+version='v0.24.3'
 
 # Visual separation bar
 separator_thick='######################################################################'


### PR DESCRIPTION
### Summary

Remove-containers and remove-images used to try to delete only postgres containers and images. It appears that the chosen solutions didn't fully bring the expected results. Thus, the functions are broadend by this fix and now don't filter for postgres anymore. Now they simply remove stopped containers and dangling images. The names in the menu have updated because of those changes aswell.