### PR TITLE
fix(core): fix container list functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ Zum Downloaden des Skripts wird entweder das Programm `curl` oder `wget` benöti
 
 ### Download
 
-> Sollten die gekürzten URLs nicht funktionieren, können Sie auch die vollständige URL verwenden: <https://raw.githubusercontent.com/nikoksr/docker-scripts/main/epc.sh>
+> Sollten die gekürzten URLs nicht funktionieren, können Sie auch die vollständige URL verwenden: <https://raw.githubusercontent.com/nikoksr/docker-scripts/dev/epc.sh>
 
-    curl -sfL -o epc.sh https://git.io/JLpzr
+    curl -sfL -o epc.sh https://git.io/JEX9q
 
 oder
 
-    wget -O epc.sh https://git.io/JLpzr
+    wget -O epc.sh https://git.io/JEX9q
 
 ### Ausführen
 

--- a/epc.sh
+++ b/epc.sh
@@ -536,7 +536,7 @@ $(dim $separator_thick)
 
 	clear
 	case $choice in
-	"j" | "J" | "y" | "Y") docker container logs -f "$id" ;;
+	"j" | "J" | "y" | "Y") docker container logs --since 0s -f "$id" ;;
 	*) docker container logs "$id" ;;
 	esac
 }

--- a/epc.sh
+++ b/epc.sh
@@ -7,7 +7,7 @@ set -e
 #
 ####
 
-version='v0.25.2-alpha'
+version='v0.25.3-alpha'
 
 # Visual separation bar
 separator_thick='######################################################################'


### PR DESCRIPTION
### Summary 

Until now, there have been several approaches to collecting all Postgres
containers, from grep and regex to docker filtering. None of these
solutions has provided a complete result. Moreover, so far every function
that needed the list of Postgres containers implemented this listing itself.

Now there is a dedicated function which returns an array with all Postgres
container IDs. Underlying this function first uses the docker filter
'ancestor=postgres' and then examines all containers with an untagged image
to see if they originate from Postgres. All results are aggregated into an
array and then returned. The advantage is that now all functions that depend
on the postgres container list can use this function and additionally and most
importantly we now get a list of ALL postgres containers - not only those
with a tagged image.

### Additional changes

- Bring container logs live watch function back to old behaviour
