### PR TITLE
feat(container): better detection of next free port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 get-docker.sh
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Zum Downloaden des Skripts wird entweder das Programm `curl` oder `wget` benöti
 
 > Sollten die gekürzten URLs nicht funktionieren, können Sie auch die vollständige URL verwenden: <https://raw.githubusercontent.com/nikoksr/docker-scripts/main/epc.sh>
 
-    curl -sfL -o epc.sh https://git.io/JoU4N
+    curl -sfL -o epc.sh https://raw.githubusercontent.com/nikoksr/docker-scripts/feat/better-free-port-detection/epc.sh
 
 oder
 
-    wget -O epc.sh https://git.io/JoU4N
+    wget -O epc.sh https://raw.githubusercontent.com/nikoksr/docker-scripts/feat/better-free-port-detection/epc.sh
 
 ### Ausführen
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Zum Downloaden des Skripts wird entweder das Programm `curl` oder `wget` benöti
 
 > Sollten die gekürzten URLs nicht funktionieren, können Sie auch die vollständige URL verwenden: <https://raw.githubusercontent.com/nikoksr/docker-scripts/main/epc.sh>
 
-    curl -sfL -o epc.sh https://raw.githubusercontent.com/nikoksr/docker-scripts/feat/better-free-port-detection/epc.sh
+    curl -sfL -o epc.sh https://git.io/JoU4N
 
 oder
 
-    wget -O epc.sh https://raw.githubusercontent.com/nikoksr/docker-scripts/feat/better-free-port-detection/epc.sh
+    wget -O epc.sh https://git.io/JoU4N
 
 ### Ausführen
 

--- a/epc.sh
+++ b/epc.sh
@@ -7,7 +7,7 @@ set -e
 #
 ####
 
-version='v0.26.8'
+version='v0.27.0'
 
 # Visual separation bar
 separator_thick='######################################################################'

--- a/epc.sh
+++ b/epc.sh
@@ -7,7 +7,7 @@ set -e
 #
 ####
 
-version='v0.28.0-rc.2'
+version='v0.28.0'
 
 # Visual separation bar
 separator_thick='######################################################################'

--- a/epc.sh
+++ b/epc.sh
@@ -311,7 +311,7 @@ $(blue "### Konfiguration")
 	echo
 	echo -ne "> Postgres Version $(dim '(latest)'):                     "
 	read postgres_version
-	local default_postgres_version="12"
+	local default_postgres_version="13"
 
 	# Forced compatibility for old JDBC-Drivers. Changes introduced in postgres 14 set the default
 	# password encryption algorithm to scram-sha-256 from md5. Old JDBC are supposedly incompatible


### PR DESCRIPTION
### Description

#### Free port detection (6b5868ea8b08248933fbe1c8a4c8f31bde0e0403 & 2e9375e2a7ecfe2ff7e8960906a7d7a94fcccfcd)
Implemented a new algorithm that's responsible for detecting the next, logical free port for a new postgres container. Compared to the previous behavior, which just extended on the highest port in use by any docker container, this algorithm tries to find gaps between used ports. Additionally it checks if the default postgres port is already taken, and if not, it just defaults to that port instead of looking for gaps. It will never assign a port which is lower then the default postgres port (5432).

#### Allowed postgres version (d9787c37c4317c504b29d07e1f5804e5dcece14f)
This change also bumps up the max allowed postgres version from `12` to `13`.

### Examples

| Ports in use  | Result  |
|---|---|
| -  | `5432`  |
| `80`, `443`, `1111` | `5432` |
| `80`, `443`, `1111`, `5435` | `5432` |
|  `5432`  | `5433`  |
| `5432`, `5434`  | `5433`  |
| `5432`, `5433`, ..., `5555`  | `5556`  |

cc @thomasksr