### PR TITLE
fix(ports): inspect fails when no containers are running

### DIFF
--- a/epc.sh
+++ b/epc.sh
@@ -337,10 +337,19 @@ $(blue "### Konfiguration")
 
 	echo
 
-	ports="$(docker inspect $(docker container ls --format '{{.ID}}') | grep -i 'HostPort' | grep -Po '(?<=\"HostPort\"\: \")\d+(?=\")' | sort -n | uniq)"
-  readarray -t ports <<<"$ports"
 
   # Container Port
+
+	# Only check for reserved ports, if there are any containers running. Else, just leave the ports array empty.
+	local container_ids=$(docker container ls --format '{{.ID}}')
+	local ports=()
+
+	if [ -n "$container_ids" ]; then
+	  ports="$(docker inspect $container_ids | grep -i 'HostPort' | grep -Po '(?<=\"HostPort\"\: \")\d+(?=\")' | sort -n | uniq)"
+    readarray -t ports <<<"$ports"
+  fi
+
+  # Pick the first available port
   highest_port="$(pick_port "${ports[@]}")"
 
 	echo -ne "> Port $(dim '('"$highest_port"')'):                                   "


### PR DESCRIPTION
### Description

Before loading the reserved ports through `docker inspect` we now check if there are any containers running in the first place. Previously, in case that no containers were running, the inspect command returned an error because it received no container ids to inspect. Now we skip the inspect command if there no containers exist in the first place.