### PR TITLE
fix(docker): infinite container wait

### DIFF
--- a/epc.sh
+++ b/epc.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+
 set -e
 
 #################################################
 # GLOBAL VARIABLES
 #################################################
 
-VERSION='v0.31.2-alpha'
+VERSION='v0.31.2'
 
 # This is the url to the official Docker install script which will be used here to.. install docker.
 INSTALL_SCRIPT_URL="https://get.docker.com/"

--- a/epc.sh
+++ b/epc.sh
@@ -577,15 +577,11 @@ $(blue "### Konfiguration")
 
     # Only create database if name was given. Skip on empty.
     if [ -n "$db_name" ] && [ ! "$db_name" = "postgres" ]; then
-
-      echo -ne "$(blue "### Datenbank für Container '$container_name' erstellen")\n\n"
-
       # Wait 90 seconds for container to start
       is_running=1
       while [[ $i -lt 90 ]]; do
-        echo -ne "$(blue "### Warte auf Container '$container_name'")\n\n"
         # Send basic select query to database to check if it is running
-        if docker exec "$container_name" psql -U postgres -c "SELECT 1" >/dev/null 2>&1 >/dev/null 2>&1; then
+        if docker exec "$container_name" psql -U postgres -c "SELECT 1" >/dev/null 2>&1; then
           is_running=0
           break
         fi
@@ -595,16 +591,16 @@ $(blue "### Konfiguration")
 
       # Check if container is running and create database if so.
       if [ "$is_running" -eq 0 ]; then
-        docker exec -it "$container_name" psql -U postgres -c "CREATE DATABASE $db_name;" &&
-          echo "> Datenbank $db_name erfolgreich erstellt..."
+        docker exec -it "$container_name" psql -U postgres -c "CREATE DATABASE $db_name;" >/dev/null 2>&1 &&
+          echo -e "> Datenbank $(dim $db_name) erfolgreich erstellt"
       else
-        echo "> $(red 'Warnung:') Konnte Datenbank nicht anlegen, da Container nicht im erwarteten Zeitraum gestartet ist..."
+        echo -e "> $(red 'Warnung:') Konnte Datenbank nicht anlegen, da Container nicht im erwarteten Zeitraum gestartet ist"
       fi
     fi
 
     echo -e "> Container $(dim $container_name) gestartet auf $(green "$ip":"$port")"
+    echo
   done
-  echo
 }
 
 list_postgres_containers() {

--- a/epc.sh
+++ b/epc.sh
@@ -5,7 +5,7 @@ set -e
 # GLOBAL VARIABLES
 #################################################
 
-VERSION='v0.31.0-alpha'
+VERSION='v0.31.1-alpha'
 
 # This is the url to the official Docker install script which will be used here to.. install docker.
 INSTALL_SCRIPT_URL="https://get.docker.com/"
@@ -543,7 +543,6 @@ $(blue "### Konfiguration")
   fi
 
   echo
-
   echo -ne "$(blue "### Postgres Image laden")\n\n"
   docker pull "$DOCKER_REPO":"$postgres_version"
 
@@ -579,14 +578,18 @@ $(blue "### Konfiguration")
     # Only create database if name was given. Skip on empty.
     if [ -n "$db_name" ] && [ ! "$db_name" = "postgres" ]; then
 
+      echo -ne "$(blue "### Datenbank für Container '$container_name' erstellen")\n\n"
+
       # Wait 90 seconds for container to start
       is_running=1
       while [[ $i -lt 90 ]]; do
-        if [[ "$(docker exec $container_name pg_isready)" == *"accepting"* ]]; then
+        echo -ne "$(blue "### Warte auf Container '$container_name'")\n\n"
+        # Send basic select query to database to check if it is running
+        if docker exec "$container_name" psql -U postgres -c "SELECT 1" >/dev/null 2>&1 >/dev/null 2>&1; then
           is_running=0
           break
         fi
-        sleep 1s
+        sleep 0.05
         i=$(("$i" + 1))
       done
 

--- a/epc.sh
+++ b/epc.sh
@@ -462,14 +462,15 @@ $(blue "### Konfiguration")
   fi
 
   # Logging behaviour
+  default_log_file_num="3"
   echo
-  echo -ne "> Maximal Anzahl Log Dateien $(dim '(5)'):                "
+  echo -ne "> Maximal Anzahl Log Dateien $(dim '('$default_log_file_num')'):                "
   read max_log_file
   if [ -z "$max_log_file" ]; then
-    max_log_file="5"
+    max_log_file="$default_log_file_num"
   fi
 
-  default_log_file_size="20m"
+  default_log_file_size="1g"
   echo -ne "> Maximale Größe einer Log-Datei $(dim '('$default_log_file_size')'):         "
   read max_log_file_size
   if [ -z "$max_log_file_size" ]; then
@@ -565,6 +566,7 @@ $(blue "### Konfiguration")
 
     docker run \
       --name "$container_name" \
+      --log-driver local \
       --log-opt max-file="$max_log_file" \
       --log-opt max-size="$max_log_file_size" \
       --publish "$port":5432 \

--- a/epc.sh
+++ b/epc.sh
@@ -5,7 +5,7 @@ set -e
 # GLOBAL VARIABLES
 #################################################
 
-VERSION='v0.31.1-alpha'
+VERSION='v0.31.2-alpha'
 
 # This is the url to the official Docker install script which will be used here to.. install docker.
 INSTALL_SCRIPT_URL="https://get.docker.com/"
@@ -565,7 +565,6 @@ $(blue "### Konfiguration")
 
     docker run \
       --name "$container_name" \
-      --log-driver local \
       --log-opt max-file="$max_log_file" \
       --log-opt max-size="$max_log_file_size" \
       --publish "$port":5432 \

--- a/epc.sh
+++ b/epc.sh
@@ -5,7 +5,7 @@ set -e
 # GLOBAL VARIABLES
 #################################################
 
-VERSION='v0.30.0'
+VERSION='v0.31.0-alpha'
 
 # This is the url to the official Docker install script which will be used here to.. install docker.
 INSTALL_SCRIPT_URL="https://get.docker.com/"


### PR DESCRIPTION
### Description 

An earlier version introduced support for custom docker repositories. Recently it was discovered that the images under nikoksr/postgres caused the script to wait infinitely for containers to start.

After manual investigation it became obvious however that the containers and postgres were indeed up and running. The problem was triggered by the altered encoding that the images in nikoksr/postgres use. They switch from EN to DE, causing postgres toolchain to also behave differently.

Until recently we checked the return value of pg_ready for a specific ENGLISH string. Obviously this does not work well in a german system..

For the fix we adapted the test we use for postres' readyness. Instead of relying on pg_ready, we now send the simplest select possible into the database and wait for it to become successful.

Also reduced the interval in which we check for readyness from 1 second to 50 milliseconds.

Closes #25 